### PR TITLE
fix(backend): improve booking, review and public property flows

### DIFF
--- a/src/bookings/bookings.service.spec.ts
+++ b/src/bookings/bookings.service.spec.ts
@@ -1,17 +1,29 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BookingsService } from './bookings.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { ForbiddenException } from '@nestjs/common';
 
 describe('BookingsService', () => {
   let service: BookingsService;
+  let prisma: {
+    booking: {
+      findMany: jest.Mock;
+    };
+  };
 
   beforeEach(async () => {
+    prisma = {
+      booking: {
+        findMany: jest.fn(),
+      },
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BookingsService,
         {
           provide: PrismaService,
-          useValue: {},
+          useValue: prisma,
         },
       ],
     }).compile();
@@ -21,5 +33,85 @@ describe('BookingsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('findByUser', () => {
+    it('allows a user to fetch their own bookings across property tenants', async () => {
+      const bookings = [
+        {
+          id: 16,
+          userId: 25,
+          propertyId: 8,
+          tenantId: 11,
+          property: {
+            id: 8,
+            title: 'Beach Apartment',
+            location: 'Vlora',
+            price: 110,
+          },
+          payments: [],
+        },
+      ];
+
+      prisma.booking.findMany.mockResolvedValue(bookings);
+
+      await expect(
+        service.findByUser(25, {
+          sub: 25,
+          email: 'h@gmail.com',
+          roleId: 1,
+          role: 'USER',
+          tenantId: 19,
+        }),
+      ).resolves.toBe(bookings);
+
+      expect(prisma.booking.findMany).toHaveBeenCalledWith({
+        where: {
+          userId: 25,
+        },
+        include: {
+          property: {
+            select: {
+              id: true,
+              title: true,
+              location: true,
+              price: true,
+            },
+          },
+          payments: true,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+    });
+
+    it('allows admins to fetch bookings for another user', async () => {
+      prisma.booking.findMany.mockResolvedValue([]);
+
+      await expect(
+        service.findByUser(25, {
+          sub: 1,
+          email: 'admin@example.com',
+          roleId: 3,
+          role: 'ADMIN',
+          tenantId: 19,
+        }),
+      ).resolves.toEqual([]);
+    });
+
+    it('forbids non-admins from fetching another user bookings', async () => {
+      await expect(
+        service.findByUser(25, {
+          sub: 26,
+          email: 'other@example.com',
+          roleId: 1,
+          role: 'USER',
+          tenantId: 19,
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+
+      expect(prisma.booking.findMany).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/bookings/bookings.service.ts
+++ b/src/bookings/bookings.service.ts
@@ -1,8 +1,8 @@
 import {
   BadRequestException,
-  ForbiddenException,
   Injectable,
   NotFoundException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateBookingDto } from './dto/create-booking.dto';
@@ -58,16 +58,19 @@ export class BookingsService {
       where: { id: createBookingDto.propertyId },
     });
 
-    if (!property || property.tenantId !== currentUser.tenantId) {
+    if (!property) {
       throw new NotFoundException(
         `Property with id ${createBookingDto.propertyId} not found`,
       );
     }
 
-    const bookingUserId =
-      currentUser.role === 'ADMIN'
-        ? (createBookingDto.userId ?? currentUser.sub)
-        : currentUser.sub;
+    if (property.status !== 'ACTIVE') {
+      throw new BadRequestException(
+        `Property with id ${createBookingDto.propertyId} is not active`,
+      );
+    }
+
+    const bookingUserId = currentUser.sub;
 
     const bookingUser = await this.prisma.user.findUnique({
       where: { id: bookingUserId },
@@ -81,7 +84,7 @@ export class BookingsService {
       where: {
         propertyId: createBookingDto.propertyId,
         status: {
-          in: ['PENDING', 'CONFIRMED'],
+          not: 'CANCELLED',
         },
         AND: [
           {
@@ -114,7 +117,7 @@ export class BookingsService {
       data: {
         startDate,
         endDate,
-        status: createBookingDto.status || 'PENDING',
+        status: 'PENDING',
         totalPrice,
         userId: bookingUserId,
         propertyId: createBookingDto.propertyId,
@@ -170,14 +173,6 @@ export class BookingsService {
   }
 
   async findByUser(userId: number, currentUser: JwtPayload) {
-    const user = await this.prisma.user.findUnique({
-      where: { id: userId },
-    });
-
-    if (!user || user.tenantId !== currentUser.tenantId) {
-      throw new NotFoundException(`User with id ${userId} not found`);
-    }
-
     if (currentUser.role !== 'ADMIN' && userId !== currentUser.sub) {
       throw new ForbiddenException('You cannot access bookings for this user');
     }
@@ -185,10 +180,16 @@ export class BookingsService {
     return this.prisma.booking.findMany({
       where: {
         userId,
-        tenantId: currentUser.tenantId,
       },
       include: {
-        property: true,
+        property: {
+          select: {
+            id: true,
+            title: true,
+            location: true,
+            price: true,
+          },
+        },
         payments: true,
       },
       orderBy: {

--- a/src/bookings/dto/create-booking.dto.ts
+++ b/src/bookings/dto/create-booking.dto.ts
@@ -1,4 +1,4 @@
-import { IsDateString, IsInt, IsOptional, IsString } from 'class-validator';
+import { IsDateString, IsInt } from 'class-validator';
 
 export class CreateBookingDto {
   @IsDateString()
@@ -6,14 +6,6 @@ export class CreateBookingDto {
 
   @IsDateString()
   endDate!: string;
-
-  @IsOptional()
-  @IsString()
-  status?: string;
-
-  @IsOptional()
-  @IsInt()
-  userId?: number;
 
   @IsInt()
   propertyId!: number;

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,17 +7,19 @@ import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.enableCors({
-    origin: [
-      'http://localhost:3000',
-      'http://localhost:3001',
-      'http://localhost:3002',
-      'http://localhost:5173',
-      'http://127.0.0.1:3002',
-      'http://127.0.0.1:5173',
-    ],
-    credentials: true,
-  });
+ app.enableCors({
+  origin: [
+    'http://localhost:3001',
+    'http://localhost:3002',
+    'http://localhost:3003',
+    'http://localhost:5173',
+    'http://127.0.0.1:3001',
+    'http://127.0.0.1:3002',
+    'http://127.0.0.1:3003',
+    'http://127.0.0.1:5173',
+  ],
+  credentials: true,
+});
   app.use(helmet());
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/properties/properties.service.ts
+++ b/src/properties/properties.service.ts
@@ -71,15 +71,16 @@ export class PropertiesService {
   }
 
   async findOne(id: number, currentUser: JwtPayload) {
-    const property = await this.prisma.property.findFirst({
-      where: {
-        id,
-        tenantId: currentUser.tenantId,
-      },
+    const property = await this.prisma.property.findUnique({
+      where: { id },
       include: this.propertySelection,
     });
 
-    if (!property) {
+    if (
+      !property ||
+      (property.tenantId !== currentUser.tenantId &&
+        property.status !== 'ACTIVE')
+    ) {
       throw new NotFoundException(`Property with id ${id} not found`);
     }
 

--- a/src/reviews/dto/create-review.dto.ts
+++ b/src/reviews/dto/create-review.dto.ts
@@ -1,5 +1,18 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsNotEmpty, IsString, Max, Min } from 'class-validator';
+
 export class CreateReviewDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(5)
   rating: number;
+
+  @IsString()
+  @IsNotEmpty()
   comment: string;
+
+  @Type(() => Number)
+  @IsInt()
   propertyId: number;
 }

--- a/src/reviews/dto/update-review.dto.ts
+++ b/src/reviews/dto/update-review.dto.ts
@@ -1,4 +1,15 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
 export class UpdateReviewDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(5)
   rating?: number;
+
+  @IsOptional()
+  @IsString()
   comment?: string;
 }

--- a/src/reviews/reviews.service.spec.ts
+++ b/src/reviews/reviews.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ReviewsService } from './reviews.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 
 describe('ReviewsService', () => {
   let service: ReviewsService;
@@ -16,7 +17,7 @@ describe('ReviewsService', () => {
       delete: jest.fn(),
     },
     property: {
-      findUnique: jest.fn(),
+      findFirst: jest.fn(),
     },
     user: {
       findUnique: jest.fn(),
@@ -35,9 +36,158 @@ describe('ReviewsService', () => {
     }).compile();
 
     service = module.get<ReviewsService>(ReviewsService);
+
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('createReview', () => {
+    const currentUser = {
+      sub: 26,
+      email: 'reviewer@example.com',
+      roleId: 3,
+      role: 'TENANT',
+      tenantId: 20,
+    };
+
+    it('creates a review for an active property from another tenant', async () => {
+      const property = {
+        id: 8,
+        title: 'Beach Apartment',
+        tenantId: 11,
+        status: 'ACTIVE',
+      };
+      const review = {
+        id: 21,
+        propertyId: 8,
+        userId: 26,
+        tenantId: 11,
+        rating: 5,
+        comment: 'test review',
+      };
+
+      mockPrismaService.property.findFirst.mockResolvedValue(property);
+      mockPrismaService.user.findUnique.mockResolvedValue({
+        id: 26,
+        tenantId: 20,
+      });
+      mockPrismaService.review.findFirst.mockResolvedValue(null);
+      mockPrismaService.review.create.mockResolvedValue(review);
+
+      await expect(
+        service.createReview(
+          { propertyId: 8, rating: 5, comment: 'test review' },
+          currentUser,
+        ),
+      ).resolves.toBe(review);
+
+      expect(mockPrismaService.property.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 8,
+          status: 'ACTIVE',
+        },
+      });
+      expect(mockPrismaService.review.create).toHaveBeenCalledWith({
+        data: {
+          rating: 5,
+          comment: 'test review',
+          userId: 26,
+          propertyId: 8,
+          tenantId: 11,
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              email: true,
+            },
+          },
+          property: {
+            select: {
+              id: true,
+              title: true,
+            },
+          },
+        },
+      });
+    });
+
+    it('rejects inactive or missing properties', async () => {
+      mockPrismaService.property.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.createReview(
+          { propertyId: 8, rating: 5, comment: 'test review' },
+          currentUser,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('keeps duplicate review prevention', async () => {
+      mockPrismaService.property.findFirst.mockResolvedValue({
+        id: 8,
+        tenantId: 11,
+        status: 'ACTIVE',
+      });
+      mockPrismaService.user.findUnique.mockResolvedValue({
+        id: 26,
+        tenantId: 20,
+      });
+      mockPrismaService.review.findFirst.mockResolvedValue({ id: 1 });
+
+      await expect(
+        service.createReview(
+          { propertyId: 8, rating: 5, comment: 'test review' },
+          currentUser,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('getPropertyReviews', () => {
+    it('returns reviews for an active property without tenant filtering', async () => {
+      mockPrismaService.property.findFirst.mockResolvedValue({
+        id: 8,
+        tenantId: 11,
+        status: 'ACTIVE',
+      });
+      mockPrismaService.review.findMany.mockResolvedValue([]);
+
+      await expect(
+        service.getPropertyReviews(8, {
+          sub: 26,
+          email: 'reviewer@example.com',
+          roleId: 3,
+          role: 'TENANT',
+          tenantId: 20,
+        }),
+      ).resolves.toEqual([]);
+
+      expect(mockPrismaService.review.findMany).toHaveBeenCalledWith({
+        where: {
+          propertyId: 8,
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              email: true,
+            },
+          },
+          property: {
+            select: {
+              id: true,
+              title: true,
+            },
+          },
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+    });
   });
 });

--- a/src/reviews/reviews.service.ts
+++ b/src/reviews/reviews.service.ts
@@ -13,15 +13,15 @@ import { JwtPayload } from '../auth/jwt-payload.type';
 export class ReviewsService {
   constructor(private prisma: PrismaService) {}
 
-  private async verifyPropertyTenant(
-    propertyId: number,
-    currentUser: JwtPayload,
-  ) {
-    const property = await this.prisma.property.findUnique({
-      where: { id: propertyId },
+  private async verifyActiveProperty(propertyId: number) {
+    const property = await this.prisma.property.findFirst({
+      where: {
+        id: propertyId,
+        status: 'ACTIVE',
+      },
     });
 
-    if (!property || property.tenantId !== currentUser.tenantId) {
+    if (!property) {
       throw new NotFoundException('Property not found');
     }
 
@@ -52,7 +52,7 @@ export class ReviewsService {
       throw new BadRequestException('Comment is required');
     }
 
-    const property = await this.verifyPropertyTenant(dto.propertyId, currentUser);
+    const property = await this.verifyActiveProperty(dto.propertyId);
 
     const user = await this.prisma.user.findUnique({
       where: { id: currentUser.sub },
@@ -99,12 +99,11 @@ export class ReviewsService {
   }
 
   async getPropertyReviews(propertyId: number, currentUser: JwtPayload) {
-    await this.verifyPropertyTenant(propertyId, currentUser);
+    await this.verifyActiveProperty(propertyId);
 
     return this.prisma.review.findMany({
       where: {
         propertyId,
-        tenantId: currentUser.tenantId,
       },
       include: {
         user: {
@@ -127,12 +126,11 @@ export class ReviewsService {
   }
 
   async getAverageRating(propertyId: number, currentUser: JwtPayload) {
-    await this.verifyPropertyTenant(propertyId, currentUser);
+    await this.verifyActiveProperty(propertyId);
 
     const result = await this.prisma.review.aggregate({
       where: {
         propertyId,
-        tenantId: currentUser.tenantId,
       },
       _avg: {
         rating: true,

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -49,7 +49,9 @@ export class SearchService {
     const limit = Number(query.limit) || 10;
     const skip = (page - 1) * limit;
 
-    const where: any = {};
+    const where: any = {
+      status: 'ACTIVE',
+    };
 
     if (query.location) {
       where.location = {


### PR DESCRIPTION
Changes:
- Booking form now redirects only after successful booking
- Booking errors are displayed inside the form
- Reserve button is disabled while submitting
- Dashboard fetches the current user and real backend bookings
- Dashboard no longer shows mock bookings when backend is reachable
- API service normalizes booking responses for dashboard display
- Logout calls backend /auth/logout before clearing local tokens
- Homepage uses public /search/properties instead of protected /properties
- Review helper uses property review endpoints
- Added .env.example with VITE_API_URL
- Fixed corrupted UI separator characters
- Updated homepage copy to look production-ready

Verification:
- npm run build passed
- Booking success flow tested
- Booking overlap error tested
- Dashboard bookings tested
- Review creation tested